### PR TITLE
feat: live prompts use `publishedAt` date rather than the `createdAt` date

### DIFF
--- a/packages/backend/src/api/v1/template-versions.ts
+++ b/packages/backend/src/api/v1/template-versions.ts
@@ -128,6 +128,9 @@ versions.patch(
           test_values: sql.json(testValues),
           is_draft: isDraft,
           notes,
+
+          /* publishedAt is set to curnt date if the template is not a draft */
+          publishedAt: isDraft ? undefined : sql`now()`,
         }),
       )}
       where 

--- a/packages/backend/src/api/v1/template-versions.ts
+++ b/packages/backend/src/api/v1/template-versions.ts
@@ -128,9 +128,7 @@ versions.patch(
           test_values: sql.json(testValues),
           is_draft: isDraft,
           notes,
-
-          /* publishedAt is set to curnt date if the template is not a draft */
-          publishedAt: isDraft ? undefined : sql`now()`,
+          publishedAt: isDraft ? null : sql`now()`,
         }),
       )}
       where 

--- a/packages/db/0044.sql
+++ b/packages/db/0044.sql
@@ -1,0 +1,1 @@
+alter table template_version add column published_at timestamp with time zone default null;


### PR DESCRIPTION
I added a column `publishedAt` in the `template_version` table which is updated if the `isDraft` column is set to false in the `/template_versions/{id}` `PATCH` request.

I also left the `createdAt` column as a fallback since the default value of the `publishedAt` column is null.