### PR TITLE
fix: metadata persistence

### DIFF
--- a/packages/backend/src/api/v1/runs/ingest.ts
+++ b/packages/backend/src/api/v1/runs/ingest.ts
@@ -175,7 +175,7 @@ async function registerRunEvent(
       output = JSON.stringify(output)
     }
 
-    const runToInsert = {
+    const runToInsert = clearUndefined({
       endedAt: timestamp,
       output: output,
       status: "success",
@@ -183,7 +183,7 @@ async function registerRunEvent(
       completionTokens: tokensUsage?.completion,
       cost,
       metadata,
-    }
+    })
     if (!runToInsert.metadata) {
       delete runToInsert.metadata
     }


### PR DESCRIPTION
fix overwriting of the metadata on the 'end' event with null. Otherwise i.e. metadata that is sent with langchain isn't stored in the trace.