### PR TITLE
fix: openai to anthropic tool conversion

### DIFF
--- a/packages/backend/src/utils/playground.ts
+++ b/packages/backend/src/utils/playground.ts
@@ -359,6 +359,9 @@ export async function runAImodel(
 
   const useAnthropic = modelObj?.provider === "anthropic";
   if (useAnthropic) {
+    if (!process.env.ANTHROPIC_API_KEY)
+      throw Error("No Anthropic API key found");
+
     const anthropic = new Anthropic({
       apiKey: process.env.ANTHORPIC_API_KEY,
     });
@@ -388,15 +391,25 @@ export async function runAImodel(
 
   switch (modelObj?.provider) {
     case "openai":
-      clientParams = getOpenAIParams();
+      const params = getOpenAIParams();
+      if (!params)
+        throw Error("No OpenAI API key found");
+
+      clientParams = params;
       break;
     case "mistral":
+      if (!process.env.MISTRAL_API_KEY)
+        throw Error("No Mistral API key found");
+
       clientParams = {
         apiKey: process.env.MISTRAL_API_KEY,
         baseURL: "https://api.mistral.ai/v1/",
       };
       break;
     case "openrouter":
+      if (!process.env.OPENROUTER_API_KEY)
+        throw Error("No OpenRouter API key found");
+
       clientParams = {
         apiKey: process.env.OPENROUTER_API_KEY,
         baseURL: "https://openrouter.ai/api/v1",

--- a/packages/frontend/components/prompts/Provider.tsx
+++ b/packages/frontend/components/prompts/Provider.tsx
@@ -23,26 +23,6 @@ import Link from "next/link";
 import { IconInfoCircle, IconTools } from "@tabler/icons-react";
 
 function convertOpenAIToolsToAnthropic(openAITools) {
-  function convertProperties(openAIProperties) {
-    const anthropicProperties = {};
-
-    for (const [key, value] of Object.entries(openAIProperties)) {
-      const anthropicProperty = {
-        type: value.type,
-        description: value.description,
-      };
-
-      if (value.type === "object" && value.properties) {
-        anthropicProperty.properties = convertProperties(value.properties);
-        anthropicProperty.required = value.required || [];
-      }
-
-      anthropicProperties[key] = anthropicProperty;
-    }
-
-    return anthropicProperties;
-  }
-
   return openAITools.map((openAITool) => {
     const openAIFunction = openAITool.function;
 
@@ -53,16 +33,8 @@ function convertOpenAIToolsToAnthropic(openAITools) {
     const anthropicTool = {
       name: openAIFunction.name,
       description: openAIFunction.description,
-      input_schema: {
-        type: "object",
-        properties: {},
-        required: openAIFunction.parameters.required || [],
-      },
+      input_schema: openAIFunction.parameters,
     };
-
-    anthropicTool.input_schema.properties = convertProperties(
-      openAIFunction.parameters.properties,
-    );
 
     return anthropicTool;
   });
@@ -74,11 +46,7 @@ function convertAnthropicToolsToOpenAI(anthropicTools) {
     function: {
       name: anthropicTool.name,
       description: anthropicTool.description,
-      parameters: {
-        type: "object",
-        properties: anthropicTool.input_schema.properties,
-        required: anthropicTool.input_schema.required,
-      },
+      parameters: anthropicTool.input_schema,
     },
   }));
 }


### PR DESCRIPTION
I added `if` statements to check if the needed api keys are available because this might cause issues where the user gets a misleading error, example: removing the OpenAI api key would lead to a `Cannot read property of undefined (reading 'baseURL')` error which might be hard to notice since the `getOpenAIParams` function just returns `null` if no api key is provided, which would then be passed directly to the `OpenAI` class, causing the error.