### PR TITLE
Add bulk delete to LLM logs

### DIFF
--- a/packages/frontend/utils/dataHooks/index.ts
+++ b/packages/frontend/utils/dataHooks/index.ts
@@ -484,6 +484,16 @@ export function useRun(id: string | null, initialData?: any) {
     loading: isLoading,
   };
 }
+
+export function useDeleteRunById() {
+  const { projectId } = useContext(ProjectContext);
+
+  async function deleteRunById(id: string) {
+    await fetcher.delete(generateKey(`/runs/${id}`, projectId));
+  }
+
+  return { deleteRun: deleteRunById };
+}
 export function useLogCount(filters: any) {
   const { data, isLoading } = useProjectSWR(`/runs/count?${filters}`);
 


### PR DESCRIPTION
## Summary
- allow selecting logs and removing them in bulk
- add `useDeleteRunById` helper in data hooks
- use helper instead of direct fetcher calls in logs page

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test')*
- `bun run build:frontend` *(fails: Script not found "next")*